### PR TITLE
Git Support for Google Code Project Hosting

### DIFF
--- a/src/main/resources/com/change_vision/astah/extension/plugin/easycodereverse/internal/dictionary/default.json
+++ b/src/main/resources/com/change_vision/astah/extension/plugin/easycodereverse/internal/dictionary/default.json
@@ -5,7 +5,7 @@
 	},
 	"GoogleCodeHosting": {
 		"urlPattern": "//code.google.com/p/(.*)/source/browse",
-		"rawUrls": ["//$1.googlecode.com/svn", "//$1.googlecode.com/hg"]
+		"rawUrls": ["//$1.googlecode.com/git", "//$1.googlecode.com/svn", "//$1.googlecode.com/hg"]
 	},
 	"BitBucket": {
 		"urlPattern": "//bitbucket.org/(.*)/src/(.*)/src/(.*)",


### PR DESCRIPTION
Issue #2への対応です。別にする必要がなかったので#2はCloseしました。
Google Code Project HostingがGitをサポートしてるのでそれへの追従要望。
