### PR TITLE
URLやソースコードをドロップ時に座標を変換してクラスを生成する

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,11 @@
 			<version>1.6.4</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-artifact</artifactId>
+			<version>3.0.3</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.10</version>


### PR DESCRIPTION
画面上の絶対座標から、モデル上の座標に変換してドロップされた位置にクラスが生成されるように修正。
astah 6.6.4以降のバージョンでのみ座標変換する。

同時に以下の2つの問題へも対応。
- astah 6.5以降で有効のはずのドロップ時の自動レイアウトが効いていなかった問題。
- astah 6.6以降で有効のはずの.java以外のファイルがドロップされたときに無駄な確認ダイアログを表示しないロジックが無効になっていた問題。
