### PR TITLE
Windows環境で.javaソースコードURLをドラッグ＆ドロップした際にコード解析できない問題への対応

### DIFF
--- a/src/main/java/com/change_vision/astah/extension/plugin/easycodereverse/internal/ClassDiagramDropExtension.java
+++ b/src/main/java/com/change_vision/astah/extension/plugin/easycodereverse/internal/ClassDiagramDropExtension.java
@@ -50,7 +50,18 @@ public final class ClassDiagramDropExtension extends DiagramDropTargetListener {
 	public void dropExternalData(DropTargetDropEvent dtde) {
 		if(dtde.isLocalTransfer()) return;
 		
-		if (dtde.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+		if (dtde.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+			JFrame parent = handler.getMainFrame();
+			JProgressBarDialog dialog = new JProgressBarDialog(parent, tracker);
+			
+			ParseWorker worker = new ParseWorker(dialog, new JavaCodeParser(), 
+					getURLStringFromDropContent(dtde), getLocation(dtde));
+			worker.execute();
+			
+			dialog.setVisible(true);
+			dtde.dropComplete(true);
+			layout(worker);
+		} else if (dtde.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
 			List<File> files = null;
 			if (canPreCheckSupportedFiles()) {
 				files = getFilesFromDropContent(dtde);
@@ -94,17 +105,6 @@ public final class ClassDiagramDropExtension extends DiagramDropTargetListener {
 			
 			layout(workers);
 			dtde.dropComplete(true);
-		} else if (dtde.isDataFlavorSupported(DataFlavor.stringFlavor)) {
-			JFrame parent = handler.getMainFrame();
-			JProgressBarDialog dialog = new JProgressBarDialog(parent, tracker);
-			
-			ParseWorker worker = new ParseWorker(dialog, new JavaCodeParser(), 
-					getURLStringFromDropContent(dtde), getLocation(dtde));
-			worker.execute();
-			
-			dialog.setVisible(true);
-			dtde.dropComplete(true);
-			layout(worker);
 		}
 	}
 	


### PR DESCRIPTION
[簡単コードリバース]プラグインで、モデルを正常にリバースできないことのある不具合
http://astah-users.change-vision.com/ja/modules/xhnewbb/viewtopic.php?topic_id=1829/

DataFlavor.stringFlavorのサポートチェックを優先するように修正しました。

リンクのD&Dと.javaファイルのD&Dを以下の環境で確認しました。
- Mac Yosemite + Chrome, Fireofx
- Windows + IE, Chrome, Firefox

Windows上のIE, Chrome, FirefoxからのD&DでDropTargetDropEventの確認したところ、下記が見受けられたので期待していない`DataFlavor.javaFileListFlavor`のサポートチェックでtrueになってしまい、想定外の挙動をしていたようです。
```
application/x-java-url
application/x-java-file-list
text/uri-list
Unicode String
text/plain
Plain Text
```

Mac上のChrome, FirefoxからのD&Dだと含まれていませんでした。
```
Unicode String
text/plain
Plain Text
text/plain
```